### PR TITLE
将上传 index.json 的步骤移至 build 

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -56,7 +56,14 @@ jobs:
         uses: actions/upload-pages-artifact@v1
         with:
           path: ./public
-
+      - name: Upload "index.json" to Algolia
+        uses: rxrw/algolia-index-uploader@v1
+        with:
+          index_path: "./public/index.json"
+          algolia_index_name: "shuosc_index_with_prefix" 
+          algolia_index_admin_key: ${{ secrets.ALGOLIA_APIKEY }}
+          algolia_index_id: "WDJUT0BGDL"
+          
   # Deployment job
   deploy:
     environment:
@@ -68,16 +75,3 @@ jobs:
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v1
-        
-  # Upload "index.json" to Algolia
-  generate-algolia:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - uses: caibingcheng/hugo-algolia2@v1
-        with:
-          input: "./posts/**"
-          output: "./algolia.json"
-          index: "shuosc_index_with_prefix" 
-          apikey: ${{ secrets.ALGOLIA_APIKEY }}
-          appid: "WDJUT0BGDL"


### PR DESCRIPTION
改用 rxrw/algolia-index-uploader@v1，将上传 index.json 至 Algolia 的步骤移至 build 这一 job 内，以解决上传的 index 为空的问题。