### PR TITLE
Migrate the comment area by EthanH3514

### DIFF
--- a/themes/FixIt/config.toml
+++ b/themes/FixIt/config.toml
@@ -476,7 +476,7 @@
       # FixIt 0.2.16 | CHANGED Waline comment config (https://waline.js.org)
 	  [params.page.comment.waline]
         enable = true
-        serverURL = "https://shuosc-comments.xyz/"
+        serverURL = "https://shufly-waline-sys.vercel.app/"
         pageview = false # FixIt 0.2.15 | NEW
         emoji = ["https://unpkg.com/@waline/emojis@1.1.0/bmoji",
 				 "https://unpkg.com/@waline/emojis@1.1.0/qq",	


### PR DESCRIPTION
Because the domain name has expired, I migrate the comment area to my private github repository. And then the comment area could be used again.