### PR TITLE
Re-enable the old domain name

### DIFF
--- a/themes/FixIt/config.toml
+++ b/themes/FixIt/config.toml
@@ -476,7 +476,7 @@
       # FixIt 0.2.16 | CHANGED Waline comment config (https://waline.js.org)
 	  [params.page.comment.waline]
         enable = true
-        serverURL = "https://shuosc-comments.xyz/"
+        serverURL = "waline-comments-jer6kd3s6-young-mann.vercel.app"
         pageview = false # FixIt 0.2.15 | NEW
         emoji = ["https://unpkg.com/@waline/emojis@1.1.0/bmoji",
 				 "https://unpkg.com/@waline/emojis@1.1.0/qq",	


### PR DESCRIPTION
Because the old domain name has expired, I change back the "server URL".